### PR TITLE
AppViewControllerに、「greetingへ遷移するアクション」であることが見えるアクション名になっている。

### DIFF
--- a/ViperApp/App/AppPresenterViewAction.swift
+++ b/ViperApp/App/AppPresenterViewAction.swift
@@ -16,7 +16,7 @@ struct AppPresenterViewActionImpl: AppPresenterViewAction {
     
     // MARK: - App Presenter View Action
     
-    func greetingButtonAction() {
+    func handleButtonAction() {
         guard let view = presenter as? AppPresenterInterface else {
             return
         }

--- a/ViperApp/App/AppViewController.swift
+++ b/ViperApp/App/AppViewController.swift
@@ -18,7 +18,7 @@ protocol AppViewBehavior: ViewBehavior {
 /// View Action
 
 protocol AppViewAction: ViewAction {
-    func greetingButtonAction()
+    func handleButtonAction()
 }
 
 /// View Controller
@@ -39,7 +39,7 @@ class AppViewController: UIViewController, AppViper, AppViewBehavior {
     }
     
     @IBAction func handleButtonAction(_ sender: Any) {
-        presenter?.viewAction.greetingButtonAction()
+        presenter?.viewAction.handleButtonAction()
     }
     
     // MARK: - Navigation


### PR DESCRIPTION
プルリクの練習をさせてください(´；ω；｀)
内容はちょっと気になったレベルで、変更してもしなくても良いレベルのものです。

---

「greetingへ遷移する」かどうかをView側が知っているような見え方はよくないように思うので、Action名を変更するのはどうだろうか。
どこに遷移するかはAppのPresenterに内包するのが良いと思う。

もしくは、IBActionの名称自体を「greetingButtonAction」と動きの意味を持たせているのであれば、PresenterのAction名はそのままで良いと思う。